### PR TITLE
Update to rand 0.8.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Loïc Damien <loic.damien@dzamlo.ch>"]
 
 [dependencies]
 
-lazy_static = "0.1.15"
-libc = "0.2.0"
-rand = "0.3.11"
+lazy_static = "1.4.0"
+libc = "0.2"
+rand = "0.8.5"
+
+[dev-dependencies]
+rand_xorshift = "0.3.0"

--- a/examples/small_crush_xorshift.rs
+++ b/examples/small_crush_xorshift.rs
@@ -17,8 +17,11 @@
 
 extern crate testu01;
 extern crate rand;
+extern crate rand_xorshift;
 
 use std::ffi::CString;
+use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
 
 use testu01::unif01::{Unif01Gen, Unif01Pair};
 use testu01::swrite;
@@ -26,7 +29,7 @@ use testu01::swrite;
 // XorShiftRng doesn't implement the Debug trait but we want to print its
 // internal state.
 // This is an ugly hack to access his private members and print them.
-fn write(gen: &mut rand::XorShiftRng) {
+fn write(gen: &mut XorShiftRng) {
     let gen: &(u32, u32, u32, u32) = unsafe { std::mem::transmute(gen) };
     println!("x: 0x{:x}, y: 0x{:x}, z: 0x{:x}, w: 0x{:x}",
              gen.0,
@@ -43,7 +46,7 @@ fn main() {
     let name = "weak_rng";
     let c_name = CString::new(name).unwrap();
 
-    let rng = rand::XorShiftRng::new_unseeded(); // The generator that will be tested.
+    let rng = XorShiftRng::from_seed([0; 16]); // The generator that will be tested.
 
     // Build an object than can  be converted to something that TestU01 can test:
     let mut xorshift_unif01 = Unif01Gen::new(Unif01Pair(rng, write), c_name);

--- a/src/decorators.rs
+++ b/src/decorators.rs
@@ -19,7 +19,7 @@
 //! help you test
 //! your random number generators more thoroughly.
 
-use rand::Rng;
+use rand::{Rng, RngCore, Error};
 
 
 /// A generator that reverse the order of the bits produced by another generator.
@@ -60,7 +60,7 @@ fn reverse_bits64(bits: u64) -> u64 {
     bits
 }
 
-impl<T: Rng> Rng for ReverseBits<T> {
+impl<T: Rng> RngCore for ReverseBits<T> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         reverse_bits32(self.rng.next_u32())
@@ -69,6 +69,19 @@ impl<T: Rng> Rng for ReverseBits<T> {
     #[inline]
     fn next_u64(&mut self) -> u64 {
         reverse_bits64(self.rng.next_u64())
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest);
+        dest.reverse();
+        dest.iter_mut().for_each(|x| *x = x.reverse_bits());
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.rng.try_fill_bytes(dest)?;
+        dest.reverse();
+        dest.iter_mut().for_each(|x| *x = x.reverse_bits());
+        Ok(())
     }
 }
 
@@ -92,7 +105,7 @@ impl<T: Rng> Rng64To32<T> {
     }
 }
 
-impl<T: Rng> Rng for Rng64To32<T> {
+impl<T: Rng> RngCore for Rng64To32<T> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         if let Some(n) = self.lower_half {
@@ -103,6 +116,18 @@ impl<T: Rng> Rng for Rng64To32<T> {
             self.lower_half = Some(n as u32);
             (n >> 32) as u32
         }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.rng.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.rng.try_fill_bytes(dest)
     }
 }
 

--- a/src/decorators.rs
+++ b/src/decorators.rs
@@ -19,7 +19,7 @@
 //! help you test
 //! your random number generators more thoroughly.
 
-use rand::{Rng, RngCore, Error};
+use rand::{RngCore, Error};
 
 
 /// A generator that reverse the order of the bits produced by another generator.
@@ -27,11 +27,11 @@ use rand::{Rng, RngCore, Error};
 /// It seems that TestU01 is biased toward the most significant bits. Reversing the order of the
 /// bits allow you to detect more flaws in generators.
 #[derive(Debug)]
-pub struct ReverseBits<T: Rng> {
+pub struct ReverseBits<T: RngCore> {
     pub rng: T,
 }
 
-impl<T: Rng> ReverseBits<T> {
+impl<T: RngCore> ReverseBits<T> {
     pub fn new(rng: T) -> ReverseBits<T> {
         ReverseBits { rng: rng }
     }
@@ -60,7 +60,7 @@ fn reverse_bits64(bits: u64) -> u64 {
     bits
 }
 
-impl<T: Rng> RngCore for ReverseBits<T> {
+impl<T: RngCore> RngCore for ReverseBits<T> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         reverse_bits32(self.rng.next_u32())
@@ -91,12 +91,12 @@ impl<T: Rng> RngCore for ReverseBits<T> {
 /// TestU01 is a 32 bits test suite. You can use this decorator to transform a 64 bits generator
 /// to a 32 bit generator that use all 64 bits of it.
 #[derive(Debug)]
-pub struct Rng64To32<T: Rng> {
+pub struct Rng64To32<T: RngCore> {
     pub rng: T,
     lower_half: Option<u32>,
 }
 
-impl<T: Rng> Rng64To32<T> {
+impl<T: RngCore> Rng64To32<T> {
     pub fn new(rng: T) -> Rng64To32<T> {
         Rng64To32 {
             rng: rng,
@@ -105,7 +105,7 @@ impl<T: Rng> Rng64To32<T> {
     }
 }
 
-impl<T: Rng> RngCore for Rng64To32<T> {
+impl<T: RngCore> RngCore for Rng64To32<T> {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         if let Some(n) = self.lower_half {

--- a/src/unif01.rs
+++ b/src/unif01.rs
@@ -21,7 +21,7 @@
 use std::ffi::CString;
 use std::fmt;
 use std::ptr::null_mut;
-use rand::Rng;
+use rand::{Rng, RngCore};
 
 pub mod ffi {
 
@@ -110,7 +110,7 @@ impl<T: Unif01Methods> WithRawUnif01Gen for Unif01Gen<T> {
 }
 
 
-impl<T> Unif01Methods for T where T: Rng+fmt::Debug {
+impl<T> Unif01Methods for T where T: RngCore + fmt::Debug {
     fn get_u01(&mut self) -> f64 {
         self.gen::<f64>()
     }
@@ -126,7 +126,7 @@ impl<T> Unif01Methods for T where T: Rng+fmt::Debug {
 
 pub struct Unif01Pair<T, F>(pub T, pub F);
 
-impl<T, F> Unif01Methods for Unif01Pair<T,F> where T: Rng, F: FnMut(&mut T) {
+impl<T, F> Unif01Methods for Unif01Pair<T,F> where T: RngCore, F: FnMut(&mut T) {
     fn get_u01(&mut self) -> f64 {
         self.0.gen::<f64>()
     }


### PR DESCRIPTION
Currently when a downstream crate using `rand = "0.8.5"` imports rust-testu01 and tries to test a PRNG of its own, it gets errors because the PRNG implements the wrong version of `rand::Rng`. This PR updates the dependency so that it matches.

It also allows types to use only the `RngCore` trait, which turns out to sometimes be necessary. (I suspect that the reason for this involves the order in which extension traits are applied.)